### PR TITLE
Beheer: voeg link checker toe

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,12 @@
+name: Check published links
+on:
+  workflow_dispatch:
+  schedule:
+    # Run on Mondays at 5:45 UTC
+    - cron: '45 5 * * 1'
+
+jobs:
+  build:
+    name: Build
+    uses: Logius-standaarden/Automatisering/.github/workflows/link-checker.yml@main
+    secrets: inherit


### PR DESCRIPTION
Deze module heeft op dit moment kapotte links. Hiermee kunnen we de link checker valideren en verifieren dat als we de links updaten, ze het ook weer allemaal doen.