### PR TITLE
Beheer: fix kapotte links

### DIFF
--- a/abstract.md
+++ b/abstract.md
@@ -1,4 +1,19 @@
-The API strategy consists of a *core* &mdash; a generic set of rules for all government APIs &mdash; and various *modules* that only pertain to a specific application. See [API Strategie](https://www.geonovum.nl/node/250#APIStrategie) for a list of all parts of the API Strategy.
+This document is part of the *Nederlandse API Strategie*.
+
+The Nederlandse API Strategie consists of [a set of distinct documents](https://www.geonovum.nl/themas/kennisplatform-apis#APIStrategie).
+
+| Status           | Description & Link                                           |
+| ---------------- | ------------------------------------------------------------ |
+| Informative      | [Inleiding NL API Strategie](https://geonovum.github.io/KP-APIs/API-strategie-algemeen/Inleiding/) |
+| Informative      | [Architectuur NL API Strategie](https://geonovum.github.io/KP-APIs/API-strategie-algemeen/Architectuur/) |
+| Informative      | [Gebruikerswensen NL API Strategie](https://geonovum.github.io/KP-APIs/API-strategie-algemeen/Gebruikerswensen/) |
+| Normative        | [API Design Rules (ADR v2.0)](https://gitdocumentatie.logius.nl/publicatie/api/adr/2.0/) |
+| Normative        | [Open API Specification (OAS 3.0)](https://spec.openapis.org/oas/v3.0.1.html) |
+| Normative        | [NL GOV OAuth profiel](https://gitdocumentatie.logius.nl/publicatie/api/oauth/) |
+| Normative        | [Digikoppeling REST API koppelvlak specificatie](https://gitdocumentatie.logius.nl/publicatie/dk/restapi/) |
+| Normative module | [GEO module v1.0](https://gitdocumentatie.logius.nl/publicatie/api/mod-geo/1.0.2/) |
+
+Before reading this document it is advised to gain knowledge of the informative documents, in particular the [Architecture](https://geonovum.github.io/KP-APIs/API-strategie-algemeen/Architectuur/).
 
 <!-- below: specific part for this module only -->
 This document describes the *Geospatial module*, containing rules for geospatial content and functions in APIs.

--- a/crs.md
+++ b/crs.md
@@ -147,7 +147,7 @@ The CRS can be specified for request and response individually using parameters 
 
 <div class="rule" id="/geo/filter-crs-query-parameter">
   <p class="rulelab"><b>/geo/filter-crs-query-parameter</b>: Support passing the coordinate reference system (CRS) of the geospatial filter in the request as a query parameter</p>
-  <p>Support the <a href="http://docs.ogc.org/DRAFTS/19-079r1.html#filter-filter-crs">OGC API Features part 3 <code>filter-crs</code> parameter</a> in conformance to the standard.
+  <p>Support the <a href="https://docs.ogc.org/is/19-079r2/19-079r2.html#filter-crs-param">OGC API Features part 3 <code>filter-crs</code> parameter</a> in conformance to the standard.
   </p>
   <p>If a geospatial filter is sent to the server without these parameters, the default CRS, CRS84, is assumed as specified in <a href="#/geo/default-crs">/geo/default-crs</a>.</p>
   <p>If an invalid value, i.e. a CRS which is not in the list of supported CRSs, is given for one of these parameters, the server responds with an HTTP status code `400`.</p>
@@ -163,7 +163,7 @@ In an API that supports the creation and/or updating of items, POST, PUT or PATC
 
 <div class="rule" id="/geo/content-crs-request-header">
   <p class="rulelab"><b>/geo/content-crs-request-header</b>: When HTTP POST, PUT and/or PATCH requests are supported, pass the coordinate reference system (CRS) of geometry in the request body as a header</p>
-  <p>Support the <a href="http://docs.ogc.org/DRAFTS/20-002.html#feature-crs">OGC API Features part 4 <code>Content-Crs</code> header</a> in conformance to the standard.</p>
+  <p>Support the <a href="https://docs.ogc.org/DRAFTS/20-002r1.html#feature-crs">OGC API Features part 4 <code>Content-Crs</code> header</a> in conformance to the standard.</p>
   <p>Alternatively, if the feature representation supports expressing CRS information for each feature / geometry, the information can also be included in the feature representation. If no CRS is asserted, the default CRS, CRS84, is assumed, as stated in <a href="#/geo/default-crs">/geo/default-crs</a>.<p>
   <h4 class="rulelab">How to test</h4>
   <p>In a request (i.e. when creating or updating an item on the server):</p>

--- a/js/config.js
+++ b/js/config.js
@@ -60,7 +60,7 @@ var respecConfig = {
             version: "1.0"
         },
         "ogcapi-features-3": {
-            href: "http://docs.ogc.org/DRAFTS/19-079r1.html",
+            href: "https://docs.ogc.org/is/19-079r2/19-079r2.html",
             title: "OGC API - Features - Part 3: Filtering",
             editors: ["Panagiotis (Peter) A. Vretanos", "Clemens Portele"],
             status: "Draft",

--- a/request-response.md
+++ b/request-response.md
@@ -109,7 +109,7 @@ However, until the filtering module is written, the geospatial module retains ru
 <span name="api-38"></span>
 <div class="rule" id="/geo/geometric-context">
   <p class="rulelab"><b>/geo/geometric-context</b>: Place results of a global spatial query in the relevant geometric context</p>
-  <p>In case of a global query <code>/api/v1/_search</code>, results should be placed in the relevant geometric context, because results from different <a href="https://publicatie.centrumvoorstandaarden.nl/api/adr/#resources">collections</a>, i.e. different sets of resources of the same type, are retrieved. Express the name of the collection to which the results belong in the singular form using the property <code>type</code>. For example:</p>
+  <p>In case of a global query <code>/api/v1/_search</code>, results should be placed in the relevant geometric context, because results from different <a href="https://gitdocumentatie.logius.nl/publicatie/api/adr/2.0.2/#resources">collections</a>, i.e. different sets of resources of the same type, are retrieved. Express the name of the collection to which the results belong in the singular form using the property <code>type</code>. For example:</p>
   <pre class="example">
   // POST /api/v1/_search:
   {

--- a/request-response.md
+++ b/request-response.md
@@ -150,7 +150,7 @@ In case a REST API shall comply to the OGC API Features specification for creati
 <span name="api-34"></span>
 <div class="rule" id="/geo/geojson-request">
   <p class="rulelab"><b>/geo/geojson-request</b>: Support GeoJSON in geospatial API requests</p>
-  <p>For representing geometric information in an API, use the convention for describing geometry as defined in the GeoJSON format [[rfc7946]]. Support GeoJSON as described in <a href="http://docs.ogc.org/DRAFTS/20-002.html">OGC API Features part 4</a>, but note that this standard is still in development.</p>
+  <p>For representing geometric information in an API, use the convention for describing geometry as defined in the GeoJSON format [[rfc7946]]. Support GeoJSON as described in <a href="https://docs.ogc.org/DRAFTS/20-002r1.html">OGC API Features part 4</a>, but note that this standard is still in development.</p>
   Example: POST feature
   <pre class="example">
   // POST /collections/gebouwen/items   HTTP/1.1


### PR DESCRIPTION
Deze links waren veranderd en zijn nu weer hersteld naar de documenten waar
ze naar hadden moeten verwijzen.

Fixes #3 